### PR TITLE
add ref when component`s type is string

### DIFF
--- a/src/packages/quick-el-modal.vue
+++ b/src/packages/quick-el-modal.vue
@@ -153,7 +153,7 @@ export default {
       }
       if (typeof component === 'function') return component(h, this)
       if (typeof component === 'string') {
-        return componentIsTag ? h(component, { props, on: events }) : component
+        return componentIsTag ? h(component, { props, on: events,ref: 'modalChild' }) : component
       }
 
       return h(component, { ref: 'modalChild', props, on: events })


### PR DESCRIPTION
hi gx
I find that when component`s type is `String`, I test the event,find that not work;
So, I improve the code to ensure the test work
That`s all 